### PR TITLE
Trigger onAnimate even when animatedCurrentIndex doesn't change

### DIFF
--- a/src/components/bottomSheet/BottomSheet.tsx
+++ b/src/components/bottomSheet/BottomSheet.tsx
@@ -608,9 +608,7 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
           return;
         }
 
-        if (toIndex !== animatedCurrentIndex.value) {
-          _providedOnAnimate(animatedCurrentIndex.value, toIndex);
-        }
+        _providedOnAnimate(animatedCurrentIndex.value, toIndex);
       },
       [_providedOnAnimate, animatedSnapPoints, animatedCurrentIndex]
     );


### PR DESCRIPTION
fork of gorhom#865

for our use case, it's possible to dismiss an action sheet before it finishes its mounting animation, which makes it animate from index -1 to -1

with the way we use these action sheets (emulating a modal while using normal non-modal action sheets), this is pretty bad because it never registers an `onChange` to -1, so we don't know to properly dismiss it

we can get around this by enabling `onAnimate` to trigger in all situations, and interpreting any animation to -1 as being a dismiss