### PR TITLE
convert footer component to render function

### DIFF
--- a/src/components/bottomSheet/BottomSheet.tsx
+++ b/src/components/bottomSheet/BottomSheet.tsx
@@ -154,7 +154,7 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
       handleComponent,
       backdropComponent,
       backgroundComponent,
-      footerComponent,
+      renderFooter,
       children: Content,
     } = props;
     //#endregion
@@ -1617,10 +1617,8 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
                   >
                     {typeof Content === 'function' ? <Content /> : Content}
 
-                    {footerComponent && (
-                      <BottomSheetFooterContainer
-                        footerComponent={footerComponent}
-                      />
+                    {renderFooter && (
+                      <BottomSheetFooterContainer renderFooter={renderFooter} />
                     )}
                   </BottomSheetDraggableView>
                 </Animated.View>

--- a/src/components/bottomSheet/types.d.ts
+++ b/src/components/bottomSheet/types.d.ts
@@ -276,11 +276,11 @@ export interface BottomSheetProps
    */
   backgroundComponent?: React.FC<BottomSheetBackgroundProps> | null;
   /**
-   * Component to be placed as a footer.
+   * Function to render as the footer.
    * @see {BottomSheetFooterProps}
-   * @type React.FC\<BottomSheetFooterProps\>
+   * @type (props: BottomSheetFooterProps) => React.ReactElement | null;
    */
-  footerComponent?: React.FC<BottomSheetFooterProps>;
+  renderFooter?: (props: BottomSheetFooterProps) => React.ReactElement | null;
   /**
    * A scrollable node or normal view.
    * @type React.ReactNode[] | React.ReactNode

--- a/src/components/bottomSheetFooterContainer/BottomSheetFooterContainer.tsx
+++ b/src/components/bottomSheetFooterContainer/BottomSheetFooterContainer.tsx
@@ -1,11 +1,11 @@
-import React, { memo } from 'react';
+import { memo } from 'react';
 import { useDerivedValue } from 'react-native-reanimated';
 import { useBottomSheetInternal } from '../../hooks';
 import { KEYBOARD_STATE } from '../../constants';
 import type { BottomSheetFooterContainerProps } from './types';
 
 const BottomSheetFooterContainerComponent = ({
-  footerComponent: FooterComponent,
+  renderFooter,
 }: BottomSheetFooterContainerProps) => {
   //#region hooks
   const {
@@ -46,7 +46,7 @@ const BottomSheetFooterContainerComponent = ({
   ]);
   //#endregion
 
-  return <FooterComponent animatedFooterPosition={animatedFooterPosition} />;
+  return renderFooter({ animatedFooterPosition });
 };
 
 const BottomSheetFooterContainer = memo(BottomSheetFooterContainerComponent);

--- a/src/components/bottomSheetFooterContainer/types.d.ts
+++ b/src/components/bottomSheetFooterContainer/types.d.ts
@@ -1,4 +1,4 @@
 import type { BottomSheetProps } from '../bottomSheet';
 
 export interface BottomSheetFooterContainerProps
-  extends Required<Pick<BottomSheetProps, 'footerComponent'>> {}
+  extends Required<Pick<BottomSheetProps, 'renderFooter'>> {}


### PR DESCRIPTION
`BottomSheet` takes a `footerComponent` but if it depends on data from the component rendering it, then the pattern seems to be:
https://github.com/discord/react-native-bottom-sheet/blob/f3f9ef4d0739c4f46c8e13526c6b9d8326963769/example/app/src/screens/modal/DetachedExample.tsx#L59-L68

we're having issues where the footer will completely unmount and remount if this callback gets updated, which isn't surprising upon discovering that the `footerComponent` is used as a react component:
https://github.com/discord/react-native-bottom-sheet/blob/f3f9ef4d0739c4f46c8e13526c6b9d8326963769/src/components/bottomSheetFooterContainer/BottomSheetFooterContainer.tsx#L49

to fix this remounting problem, we can just switch from a `FooterComponent` to a `renderFooter()` function