### PR TITLE
fix onAnimate index when close()d on mount

### DIFF
--- a/src/components/bottomSheet/BottomSheet.tsx
+++ b/src/components/bottomSheet/BottomSheet.tsx
@@ -603,7 +603,9 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
     const handleOnAnimate = useCallback(
       function handleOnAnimate(toPoint: number) {
         const snapPoints = animatedSnapPoints.value;
-        const toIndex = snapPoints.indexOf(toPoint);
+        const closedPosition = animatedClosedPosition.value;
+        const toIndex =
+          toPoint === closedPosition ? -1 : snapPoints.indexOf(toPoint);
 
         print({
           component: BottomSheet.name,
@@ -620,7 +622,12 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
 
         _providedOnAnimate(animatedCurrentIndex.value, toIndex);
       },
-      [_providedOnAnimate, animatedSnapPoints, animatedCurrentIndex]
+      [
+        _providedOnAnimate,
+        animatedSnapPoints,
+        animatedClosedPosition,
+        animatedCurrentIndex,
+      ]
     );
     //#endregion
 


### PR DESCRIPTION
when calling `close()`, the action sheet will attempt to animate towards `animatedClosedPosition`:

https://github.com/discord/react-native-bottom-sheet/blob/00309effcc1bed6b4e7f3333e2690d8c1df3c93d/src/components/bottomSheet/BottomSheet.tsx#L857

and the `onAnimate` handler will try to convert that position to an index:

https://github.com/discord/react-native-bottom-sheet/blob/00309effcc1bed6b4e7f3333e2690d8c1df3c93d/src/components/bottomSheet/BottomSheet.tsx#L604-L606

*however*, `animatedSnapPoints` is a derived value that is essentially forcibly initializes every single value to `INITIAL_SNAP_POINT` (-999) until `containerHeight` is calculated:

https://github.com/discord/react-native-bottom-sheet/blob/00309effcc1bed6b4e7f3333e2690d8c1df3c93d/src/components/bottomSheet/BottomSheet.tsx#L188-L194

https://github.com/discord/react-native-bottom-sheet/blob/00309effcc1bed6b4e7f3333e2690d8c1df3c93d/src/hooks/useNormalizedSnapPoints.ts#L31-L33

which just so happens to match the `INITIAL_CONTAINER_HEIGHT` of -999 that `animatedClosedPosition` starts at

so, in summary: on mount, if a `close()` is called *before* the layout is calculated and the animated container height value is updated, `onAnimate` will interpret that position as a snap point `toIndex` of 0 instead of -1

to fix this, we can just directly compare against `closedPosition` and force an index of -1 if it matches