### PR TITLE
add source to onAnimate

### DIFF
--- a/src/components/bottomSheet/BottomSheet.tsx
+++ b/src/components/bottomSheet/BottomSheet.tsx
@@ -601,7 +601,7 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
       [_providedOnChange, animatedCurrentIndex]
     );
     const handleOnAnimate = useCallback(
-      function handleOnAnimate(toPoint: number) {
+      function handleOnAnimate(toPoint: number, source: ANIMATION_SOURCE) {
         const snapPoints = animatedSnapPoints.value;
         const closedPosition = animatedClosedPosition.value;
         const toIndex =
@@ -620,7 +620,7 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
           return;
         }
 
-        _providedOnAnimate(animatedCurrentIndex.value, toIndex);
+        _providedOnAnimate(animatedCurrentIndex.value, toIndex, source);
       },
       [
         _providedOnAnimate,
@@ -705,7 +705,7 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
         /**
          * fire `onAnimate` callback
          */
-        runOnJS(handleOnAnimate)(position);
+        runOnJS(handleOnAnimate)(position, source);
 
         /**
          * force animation configs from parameters, if provided

--- a/src/components/bottomSheet/types.d.ts
+++ b/src/components/bottomSheet/types.d.ts
@@ -250,9 +250,13 @@ export interface BottomSheetProps
   /**
    * Callback when the sheet about to animate to a new position.
    *
-   * @type (fromIndex: number, toIndex: number) => void;
+   * @type (fromIndex: number, toIndex: number, source: ANIMATION_SOURCE) => void;
    */
-  onAnimate?: (fromIndex: number, toIndex: number) => void;
+  onAnimate?: (
+    fromIndex: number,
+    toIndex: number,
+    source: ANIMATION_SOURCE
+  ) => void;
   //#endregion
 
   //#region components


### PR DESCRIPTION
when keyboard height updates, an action sheet will animate to a new position

if this happens on mount, it's possible for values to race in a way where the new position does not match any of the snap points, so `onAnimate` will interpret it as an animation to snap point index -1

this normally wouldn't matter since the `fromIndex` is also -1, but as of #3 we get notified of this

one solution here is to pipe through the source of the animation, so callers can check for and ignore anything occurring due to keyboard height changes