### PR TITLE
Add support for an initial scroll buffer for Scrollable components

### DIFF
--- a/src/components/bottomSheet/BottomSheet.tsx
+++ b/src/components/bottomSheet/BottomSheet.tsx
@@ -281,6 +281,7 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
       animatedScrollableContentOffsetY,
       animatedScrollableOverrideState,
       isScrollableRefreshable,
+      isScrollableLocked,
       setScrollableRef,
       removeScrollableRef,
     } = useScrollable();
@@ -370,6 +371,13 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
        * if sheet state is extended, then unlock scrolling
        */
       if (animatedSheetState.value === SHEET_STATE.EXTENDED) {
+        return SCROLLABLE_STATE.UNLOCKED;
+      }
+
+      /**
+       * if the current scrollable is blocked from translation, unlock scrolling
+       */
+      if (!isScrollableLocked.value) {
         return SCROLLABLE_STATE.UNLOCKED;
       }
 
@@ -1084,6 +1092,7 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
         isInTemporaryPosition,
         isContentHeightFixed,
         isScrollableRefreshable,
+        isScrollableLocked,
         shouldHandleKeyboardEvents,
         simultaneousHandlers: _providedSimultaneousHandlers,
         waitFor: _providedWaitFor,
@@ -1119,6 +1128,7 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
         shouldHandleKeyboardEvents,
         animatedScrollableContentOffsetY,
         isScrollableRefreshable,
+        isScrollableLocked,
         isContentHeightFixed,
         isInTemporaryPosition,
         enableContentPanningGesture,

--- a/src/components/bottomSheetScrollable/createBottomSheetScrollableComponent.tsx
+++ b/src/components/bottomSheetScrollable/createBottomSheetScrollableComponent.tsx
@@ -37,6 +37,7 @@ export function createBottomSheetScrollableComponent<T, P>(
       onRefresh,
       progressViewOffset,
       refreshControl,
+      scrollBuffer,
       // events
       onScroll,
       onScrollBeginDrag,
@@ -55,7 +56,8 @@ export function createBottomSheetScrollableComponent<T, P>(
         scrollEventsHandlersHook,
         onScroll,
         onScrollBeginDrag,
-        onScrollEndDrag
+        onScrollEndDrag,
+        scrollBuffer
       );
     const {
       enableContentPanningGesture,
@@ -104,6 +106,7 @@ export function createBottomSheetScrollableComponent<T, P>(
       type,
       scrollableContentOffsetY,
       onRefresh !== undefined,
+      scrollBuffer,
       focusHook
     );
     //#endregion

--- a/src/components/bottomSheetScrollable/types.d.ts
+++ b/src/components/bottomSheetScrollable/types.d.ts
@@ -47,6 +47,11 @@ export interface BottomSheetScrollableProps {
    * @default useScrollEventsHandlersDefault
    */
   scrollEventsHandlersHook?: ScrollEventsHandlersHookType;
+
+  /**
+   * An initial scroll buffer to prevent the bottom sheet from immediately following the scroll gesture.
+   */
+  scrollBuffer?: number;
 }
 
 export type ScrollableProps<T> =

--- a/src/contexts/internal.ts
+++ b/src/contexts/internal.ts
@@ -59,6 +59,7 @@ export interface BottomSheetInternalContextType
   animatedScrollableType: Animated.SharedValue<SCROLLABLE_TYPE>;
   animatedScrollableContentOffsetY: Animated.SharedValue<number>;
   animatedScrollableOverrideState: Animated.SharedValue<SCROLLABLE_STATE>;
+  isScrollableLocked: Animated.SharedValue<boolean>;
   isScrollableRefreshable: Animated.SharedValue<boolean>;
   isContentHeightFixed: Animated.SharedValue<boolean>;
   isInTemporaryPosition: Animated.SharedValue<boolean>;

--- a/src/hooks/useGestureEventsHandlersDefault.tsx
+++ b/src/hooks/useGestureEventsHandlersDefault.tsx
@@ -39,6 +39,7 @@ export const useGestureEventsHandlersDefault: GestureEventsHandlersHookType =
       overDragResistanceFactor,
       isInTemporaryPosition,
       isScrollableRefreshable,
+      isScrollableLocked,
       animateToPosition,
       stopAnimation,
     } = useBottomSheetInternal();
@@ -110,6 +111,14 @@ export const useGestureEventsHandlersDefault: GestureEventsHandlersHookType =
             isScrollableRefreshable.value &&
             animatedPosition.value === highestSnapPoint
           ) {
+            return;
+          }
+
+          /**
+           * if scrollable isn't currently marked as translatable, then do not
+           * interact with current gesture.
+           */
+          if (source === GESTURE_SOURCE.SCROLLABLE && !isScrollableLocked.value) {
             return;
           }
 
@@ -233,6 +242,7 @@ export const useGestureEventsHandlersDefault: GestureEventsHandlersHookType =
           context
         ) {
           const highestSnapPoint = animatedHighestSnapPoint.value;
+
           const isSheetAtHighestSnapPoint =
             animatedPosition.value === highestSnapPoint;
 
@@ -245,6 +255,10 @@ export const useGestureEventsHandlersDefault: GestureEventsHandlersHookType =
             isScrollableRefreshable.value &&
             isSheetAtHighestSnapPoint
           ) {
+            return;
+          }
+
+          if (!isScrollableLocked.value && animatedSnapPoints.value.includes(animatedPosition.value)) {
             return;
           }
 
@@ -353,6 +367,7 @@ export const useGestureEventsHandlersDefault: GestureEventsHandlersHookType =
           enablePanDownToClose,
           isInTemporaryPosition,
           isScrollableRefreshable,
+          isScrollableLocked,
           animatedClosedPosition,
           animatedHighestSnapPoint,
           animatedKeyboardHeight,

--- a/src/hooks/useScrollHandler.ts
+++ b/src/hooks/useScrollHandler.ts
@@ -12,7 +12,8 @@ export const useScrollHandler = (
   useScrollEventsHandlers = useScrollEventsHandlersDefault,
   onScroll?: ScrollableEvent,
   onScrollBeginDrag?: ScrollableEvent,
-  onScrollEndDrag?: ScrollableEvent
+  onScrollEndDrag?: ScrollableEvent,
+  scrollBuffer?: number
 ) => {
   // refs
   const scrollableRef = useAnimatedRef<Scrollable>();
@@ -27,7 +28,7 @@ export const useScrollHandler = (
     handleOnEndDrag = noop,
     handleOnMomentumEnd = noop,
     handleOnMomentumBegin = noop,
-  } = useScrollEventsHandlers(scrollableRef, scrollableContentOffsetY);
+  } = useScrollEventsHandlers(scrollableRef, scrollableContentOffsetY, scrollBuffer);
 
   // callbacks
   const scrollHandler = useAnimatedScrollHandler(

--- a/src/hooks/useScrollable.ts
+++ b/src/hooks/useScrollable.ts
@@ -18,6 +18,7 @@ export const useScrollable = () => {
     SCROLLABLE_STATE.UNDETERMINED
   );
   const isScrollableRefreshable = useSharedValue<boolean>(false);
+  const isScrollableLocked = useSharedValue<boolean>(true);
 
   // callbacks
   const setScrollableRef = useCallback((ref: ScrollableRef) => {
@@ -63,6 +64,7 @@ export const useScrollable = () => {
     animatedScrollableContentOffsetY,
     animatedScrollableOverrideState,
     isScrollableRefreshable,
+    isScrollableLocked,
     setScrollableRef,
     removeScrollableRef,
   };

--- a/src/hooks/useScrollableSetter.ts
+++ b/src/hooks/useScrollableSetter.ts
@@ -10,6 +10,7 @@ export const useScrollableSetter = (
   type: SCROLLABLE_TYPE,
   contentOffsetY: Animated.SharedValue<number>,
   refreshable: boolean,
+  scrollBuffer: number | undefined,
   useFocusHook = useEffect
 ) => {
   // hooks
@@ -18,6 +19,7 @@ export const useScrollableSetter = (
     animatedScrollableContentOffsetY: rootScrollableContentOffsetY,
     isContentHeightFixed,
     isScrollableRefreshable,
+    isScrollableLocked,
     setScrollableRef,
     removeScrollableRef,
   } = useBottomSheetInternal();
@@ -28,6 +30,7 @@ export const useScrollableSetter = (
     rootScrollableContentOffsetY.value = contentOffsetY.value;
     animatedScrollableType.value = type;
     isScrollableRefreshable.value = refreshable;
+    isScrollableLocked.value = !scrollBuffer;
     isContentHeightFixed.value = false;
 
     // set current scrollable ref
@@ -52,6 +55,7 @@ export const useScrollableSetter = (
     rootScrollableContentOffsetY,
     contentOffsetY,
     isScrollableRefreshable,
+    isScrollableLocked,
     isContentHeightFixed,
     setScrollableRef,
     removeScrollableRef,

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -154,7 +154,8 @@ type ScrollEventHandlerCallbackType<C = any> = (
 
 export type ScrollEventsHandlersHookType = (
   ref: React.RefObject<Scrollable>,
-  contentOffsetY: SharedValue<number>
+  contentOffsetY: SharedValue<number>,
+  scrollBuffer: number | undefined,
 ) => {
   handleOnScroll?: ScrollEventHandlerCallbackType;
   handleOnBeginDrag?: ScrollEventHandlerCallbackType;


### PR DESCRIPTION
Adds a new property called `scrollBuffer`, which can be added to the various `bottom-sheet` scrollable views.  It changes functionality so that the bottom sheet doesn't track the user's finger unless the scrollable view's position is past the specified `scrollBuffer`.
