### PR TITLE
[BottomSheet] Pass snap points to JS thread when update is received on UI thread

### DIFF
--- a/src/components/bottomSheet/BottomSheet.tsx
+++ b/src/components/bottomSheet/BottomSheet.tsx
@@ -610,8 +610,7 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
       [_providedOnChange, animatedCurrentIndex]
     );
     const handleOnAnimate = useCallback(
-      function handleOnAnimate(toPoint: number, source: ANIMATION_SOURCE) {
-        const snapPoints = animatedSnapPoints.value;
+      function handleOnAnimate(toPoint: number, source: ANIMATION_SOURCE, snapPoints: number[]) {
         const closedPosition = animatedClosedPosition.value;
         const toIndex =
           toPoint === closedPosition ? -1 : snapPoints.indexOf(toPoint);
@@ -714,7 +713,7 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
         /**
          * fire `onAnimate` callback
          */
-        runOnJS(handleOnAnimate)(position, source);
+        runOnJS(handleOnAnimate)(position, source, animatedSnapPoints.value);
 
         /**
          * force animation configs from parameters, if provided


### PR DESCRIPTION
Currently, action sheets in the Voice Panel UI sometimes close unintentionally when the orientation of the device changes. This can be reproduced on Android and iOS in the current alpha versions of the app. 
I traced the issue to `handleOnAnimate`, which currently is using the `animatedSnapPoints` `SharedValue`, which was resulting in the function receiving an outdated version of this value. I think this is due to the fact that the UI thread has the latest value, while the JS thread can lag behind. This race condition results in this behavior only happening sometimes. 

With this change, the action sheet never dismisses when the orientation of the device changes.

[asana task](https://app.asana.com/0/1203666918173919/1205823103449455)


Before

https://github.com/discord/react-native-bottom-sheet/assets/3458484/fca1bd16-4644-4893-944f-5a498fb65068


After


https://github.com/discord/react-native-bottom-sheet/assets/3458484/70cec019-af83-45fd-bb65-46c69a789c8e

