### PR TITLE
createBottomSheetScrollableComponent: Pass lockableScrollableContentffsetY to useScrollHandler

### DIFF
--- a/src/components/bottomSheetScrollable/createBottomSheetScrollableComponent.tsx
+++ b/src/components/bottomSheetScrollable/createBottomSheetScrollableComponent.tsx
@@ -48,6 +48,7 @@ export function createBottomSheetScrollableComponent<T, P>(
       onScroll,
       onScrollBeginDrag,
       onScrollEndDrag,
+      lockableScrollableContentOffsetY,
       onContentSizeChange,
       ...rest
       // biome-ignore lint: to be addressed!
@@ -61,7 +62,8 @@ export function createBottomSheetScrollableComponent<T, P>(
         scrollEventsHandlersHook,
         onScroll,
         onScrollBeginDrag,
-        onScrollEndDrag
+        onScrollEndDrag,
+        lockableScrollableContentOffsetY
       );
     const { animatedScrollableState, enableContentPanningGesture } =
       useBottomSheetInternal();


### PR DESCRIPTION
Please provide enough information so that others can review your pull request:

## Motivation

Explain the **motivation** for making this change. What existing problem does the pull request solve?

Relevant PRs:
- https://github.com/discord/react-native-bottom-sheet/pull/14
- https://github.com/discord/react-native-bottom-sheet/pull/15

After the 2nd PR (which moves lockableScrollableContentffsetY to scroll props), props.lockableScrollableContentffsetY wasn't getting passed to the scroll hander, so the value wasn't getting updated. This PR passes the prop down to the scroll handler.

## Links
- Asana https://app.asana.com/1/236888843494340/project/1199167684846005/task/1210664982203337?focus=true
  - This PR will fix this bug. The cause of the bug was lockableScrollableContentffsetY, passed down by the App Launcher, wasn't getting updated and was always 0. Therefore, the App Launcher header wouldn't collapse because it wasn't aware that the user was scrolling.
