### PR TITLE
fix: thumbstick

### DIFF
--- a/src/components/bottomSheetDraggableView/BottomSheetDraggableView.tsx
+++ b/src/components/bottomSheetDraggableView/BottomSheetDraggableView.tsx
@@ -24,6 +24,7 @@ const BottomSheetDraggableViewComponent = ({
     activeOffsetY,
     failOffsetX,
     failOffsetY,
+    animatedScrollableContentOffsetY,
   } = useBottomSheetInternal();
   const { contentPanGestureHandler } = useBottomSheetGestureHandlers();
   //#endregion
@@ -59,6 +60,14 @@ const BottomSheetDraggableViewComponent = ({
       .enabled(enableContentPanningGesture)
       .shouldCancelWhenOutside(false)
       .runOnJS(false)
+      .manualActivation(true)
+      .onTouchesMove((_, stateManager) => {
+        if (animatedScrollableContentOffsetY.value !== 0) {
+          stateManager.fail();
+          return;
+        }
+        stateManager.activate();
+      })
       .onStart(contentPanGestureHandler.handleOnStart)
       .onChange(contentPanGestureHandler.handleOnChange)
       .onEnd(contentPanGestureHandler.handleOnEnd)
@@ -99,6 +108,7 @@ const BottomSheetDraggableViewComponent = ({
     failOffsetY,
     simultaneousHandlers,
     waitFor,
+    animatedScrollableContentOffsetY,
     contentPanGestureHandler.handleOnChange,
     contentPanGestureHandler.handleOnEnd,
     contentPanGestureHandler.handleOnFinalize,


### PR DESCRIPTION
This fixes thumbstick issues on the Meta Quest. We need to test it on mobile devices to ensure it doesn’t break or change anything, or alternatively, hide it behind a prop/flag to enable it only on Quest devices

## Test plan

Update the commit hash in `pnpm-workspace.yaml` to the `d3312e31dc553599e2ee6b13c1146d4680c7d9d5` and verify the bottom sheets are working.