### PR TITLE
Fixup state checking for new arch reduced motion code path

### DIFF
--- a/src/components/bottomSheet/BottomSheet.tsx
+++ b/src/components/bottomSheet/BottomSheet.tsx
@@ -940,7 +940,7 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
          */
         if (
           animatedAnimationState.value !== ANIMATION_STATE.RUNNING &&
-          animatedCurrentIndex.value === -1
+          animatedIndex.value === -1
         ) {
           /**
            * early exit if reduce motion is enabled and index is out of sync with position.


### PR DESCRIPTION
## Problem
On React Native new architecture, JSI delivers prop updates to the UI thread synchronously, so `animatedSnapPoints` can update and fire the `SNAP_POINT_CHANGE` reaction before the `OnChange` reaction has had a chance to write `animatedCurrentIndex`. This creates a window where `evaluatePosition` sees `animationState === STOPPED` and `animatedCurrentIndex === -1` the "sheet stuck at closed" guard even though the sheet physically moved to an open position. It calls `setToPosition(closedPosition)` and dismisses the sheet incorrectly.

## Fix
Replace `animatedCurrentIndex` with `animatedIndex` in that guard. `animatedCurrentIndex` is a committed value that updates asynchronously via the `OnChange` reaction; `animatedIndex` is a `useDerivedValue` computed live from `animatedPosition` against the current snap points, so it always reflects where the sheet actually is. On old arch the async bridge introduced enough latency that `OnChange` always won the race so this was never observable. The fix is a no-op on old arch.

## Before / After

| Before | After |
|--------|-------|
| <video src="https://github.com/user-attachments/assets/868382c1-22a0-4895-8e59-5e5b90d6714e" autoplay loop muted playsinline></video> | <video src="https://github.com/user-attachments/assets/c286c9a6-5284-4db9-8bdc-ef53bf972705" loop muted playsinline></video> |

## Steps to repro
Enable reduced motion in system settings at Settings.app/Accessibility/Motion
With a new arch build, post a link e.g. https://google.com and then long press that link. Observe.
You'll see the before state where the bottom sheet briefly displays for a frame or so before disappearing and then the app will appear effectively frozen with the bottom sheet background in the view hierarchy absorbing all touches.



