### PR TITLE
Scroll event reentrancy guard

### DIFF
--- a/src/hooks/useScrollEventsHandlersDefault.ts
+++ b/src/hooks/useScrollEventsHandlersDefault.ts
@@ -29,10 +29,10 @@ export const useScrollEventsHandlersDefault: ScrollEventsHandlersHookType = (
   const _lockableScrollableContentOffsetY = useSharedValue(0);
 
   /**
-   * on the new renderer `scrollTo` is synchronous and, with `animated: false`,
-   * re-emits `onScroll` and `onMomentumScrollEnd` before returning. that
-   * re-enters the scroll locks below and recurses until the native stack
-   * overflows, so we suppress nested calls and let the outermost one finish.
+   * `scrollTo` is a synchronous UI-thread call, and on the new renderer a
+   * non-animated one re-emits `onScroll` and `onMomentumScrollEnd` before
+   * returning. that re-enters the scroll locks below and overflows the native
+   * stack, so we suppress nested calls and let the outermost one finish.
    */
   const isLockingScroll = useSharedValue(false);
 

--- a/src/hooks/useScrollEventsHandlersDefault.ts
+++ b/src/hooks/useScrollEventsHandlersDefault.ts
@@ -28,6 +28,14 @@ export const useScrollEventsHandlersDefault: ScrollEventsHandlersHookType = (
 
   const _lockableScrollableContentOffsetY = useSharedValue(0);
 
+  /**
+   * Tracks whether we are inside the scroll-lock `scrollTo` below, so that a
+   * synchronous re-entry into `handleOnScroll` can bail out instead of
+   * recursing. Inert on the legacy renderer, where `scrollTo` is async and the
+   * flag is always back to `false` before the next scroll event arrives.
+   */
+  const isLockingScroll = useSharedValue(false);
+
   useAnimatedReaction(
     () => _lockableScrollableContentOffsetY.value,
     _lockableScrollableContentOffsetY => {
@@ -62,11 +70,26 @@ export const useScrollEventsHandlersDefault: ScrollEventsHandlersHookType = (
         }
 
         if (animatedScrollableState.value === SCROLLABLE_STATE.LOCKED) {
+          /**
+           * On the new renderer `scrollTo` is synchronous, so it re-enters this
+           * handler before returning (`setContentOffset:` -> `_notifyDidScroll`
+           * -> `onScroll`). While a pan gesture is active the scrollable is
+           * still being driven by the gesture, so the offset never settles at
+           * `lockPosition` and every re-entry issues another `scrollTo` until
+           * the native stack overflows. Suppress the nested call and let the
+           * outermost one finish the lock.
+           */
+          if (isLockingScroll.value) {
+            return;
+          }
+
           const lockPosition = context.shouldLockInitialPosition
             ? (context.initialContentOffsetY ?? 0)
             : 0;
+          isLockingScroll.value = true;
           // @ts-ignore
           scrollTo(scrollableRef, 0, lockPosition, false);
+          isLockingScroll.value = false;
           scrollableContentOffsetY.value = lockPosition;
           _lockableScrollableContentOffsetY.value = lockPosition;
           return;
@@ -78,6 +101,7 @@ export const useScrollEventsHandlersDefault: ScrollEventsHandlersHookType = (
         scrollableContentOffsetY,
         animatedScrollableState,
         animatedSheetState,
+        isLockingScroll,
       ]
     );
   const handleOnBeginDrag: ScrollEventHandlerCallbackType<ScrollEventContextType> =

--- a/src/hooks/useScrollEventsHandlersDefault.ts
+++ b/src/hooks/useScrollEventsHandlersDefault.ts
@@ -29,10 +29,9 @@ export const useScrollEventsHandlersDefault: ScrollEventsHandlersHookType = (
   const _lockableScrollableContentOffsetY = useSharedValue(0);
 
   /**
-   * Tracks whether we are inside the scroll-lock `scrollTo` below, so that a
-   * synchronous re-entry into `handleOnScroll` can bail out instead of
-   * recursing. Inert on the legacy renderer, where `scrollTo` is async and the
-   * flag is always back to `false` before the next scroll event arrives.
+   * on the new renderer `scrollTo` is synchronous, so the scroll lock below
+   * re-enters `handleOnScroll` and recurses until the native stack overflows.
+   * we suppress the nested call and let the outermost one finish the lock.
    */
   const isLockingScroll = useSharedValue(false);
 
@@ -70,15 +69,6 @@ export const useScrollEventsHandlersDefault: ScrollEventsHandlersHookType = (
         }
 
         if (animatedScrollableState.value === SCROLLABLE_STATE.LOCKED) {
-          /**
-           * On the new renderer `scrollTo` is synchronous, so it re-enters this
-           * handler before returning (`setContentOffset:` -> `_notifyDidScroll`
-           * -> `onScroll`). While a pan gesture is active the scrollable is
-           * still being driven by the gesture, so the offset never settles at
-           * `lockPosition` and every re-entry issues another `scrollTo` until
-           * the native stack overflows. Suppress the nested call and let the
-           * outermost one finish the lock.
-           */
           if (isLockingScroll.value) {
             return;
           }

--- a/src/hooks/useScrollEventsHandlersDefault.ts
+++ b/src/hooks/useScrollEventsHandlersDefault.ts
@@ -29,9 +29,10 @@ export const useScrollEventsHandlersDefault: ScrollEventsHandlersHookType = (
   const _lockableScrollableContentOffsetY = useSharedValue(0);
 
   /**
-   * on the new renderer `scrollTo` is synchronous, so the scroll lock below
-   * re-enters `handleOnScroll` and recurses until the native stack overflows.
-   * we suppress the nested call and let the outermost one finish the lock.
+   * on the new renderer `scrollTo` is synchronous and, with `animated: false`,
+   * re-emits `onScroll` and `onMomentumScrollEnd` before returning. that
+   * re-enters the scroll locks below and recurses until the native stack
+   * overflows, so we suppress nested calls and let the outermost one finish.
    */
   const isLockingScroll = useSharedValue(false);
 
@@ -126,11 +127,17 @@ export const useScrollEventsHandlersDefault: ScrollEventsHandlersHookType = (
     useWorkletCallback(
       ({ contentOffset: { y } }, context) => {
         if (animatedScrollableState.value === SCROLLABLE_STATE.LOCKED) {
+          if (isLockingScroll.value) {
+            return;
+          }
+
           const lockPosition = context.shouldLockInitialPosition
             ? (context.initialContentOffsetY ?? 0)
             : 0;
+          isLockingScroll.value = true;
           // @ts-ignore
           scrollTo(scrollableRef, 0, lockPosition, false);
+          isLockingScroll.value = false;
           scrollableContentOffsetY.value = lockPosition;
           _lockableScrollableContentOffsetY.value = lockPosition;
           return;
@@ -148,17 +155,24 @@ export const useScrollEventsHandlersDefault: ScrollEventsHandlersHookType = (
         animatedAnimationState,
         animatedScrollableState,
         rootScrollableContentOffsetY,
+        isLockingScroll,
       ]
     );
   const handleOnMomentumEnd: ScrollEventHandlerCallbackType<ScrollEventContextType> =
     useWorkletCallback(
       ({ contentOffset: { y } }, context) => {
         if (animatedScrollableState.value === SCROLLABLE_STATE.LOCKED) {
+          if (isLockingScroll.value) {
+            return;
+          }
+
           const lockPosition = context.shouldLockInitialPosition
             ? (context.initialContentOffsetY ?? 0)
             : 0;
+          isLockingScroll.value = true;
           // @ts-ignore
           scrollTo(scrollableRef, 0, lockPosition, false);
+          isLockingScroll.value = false;
           scrollableContentOffsetY.value = 0;
           _lockableScrollableContentOffsetY.value = 0;
           return;
@@ -176,6 +190,7 @@ export const useScrollEventsHandlersDefault: ScrollEventsHandlersHookType = (
         animatedAnimationState,
         animatedScrollableState,
         rootScrollableContentOffsetY,
+        isLockingScroll,
       ]
     );
   //#endregion


### PR DESCRIPTION
This adds a guard for new arch against reentrance into this function from the scrollTo call inside of it. With new arch these calls are synchronous.

GIF picker was crashing when content was changing while the bottom sheet was being dragged between snap points due to a watch dog termination triggered by a callstack overflow from this code path.
