### PR TITLE
fix: backdrop properly detached

### DIFF
--- a/src/components/bottomSheet/BottomSheet.tsx
+++ b/src/components/bottomSheet/BottomSheet.tsx
@@ -563,7 +563,7 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
           return;
         }
 
-        if (targetIndex !== animatedCurrentIndex.value 
+        if (targetIndex !== animatedCurrentIndex.value
             // there is a race condition when opening and immedately closing the bottom sheet, where
             // the animatedCurrentIndex is not updated yet. As we don't want to miss close events we always call the callback for -1 changes:
             || targetIndex === -1) {
@@ -1152,8 +1152,6 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
 
       isInTemporaryPosition.value = false;
 
-      // Write index explicitly instead of relying on indexOf(position): during
-      // geometry updates snap point arrays can briefly disagree with the target Y.
       runOnUI(() => {
         'worklet';
         if (
@@ -1161,11 +1159,13 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
           index === animatedNextPositionIndex.value &&
           animatedAnimationState.value !== ANIMATION_STATE.RUNNING
         ) {
+          animatedCurrentIndex.value = index;
           return;
         }
 
         animatedNextPosition.value = nextPosition;
         animatedNextPositionIndex.value = index;
+        animatedCurrentIndex.value = index;
         stopAnimation();
         animatedPosition.value = nextPosition;
         animatedContainerHeightDidChange.value = false;

--- a/src/components/bottomSheetBackdrop/BottomSheetBackdrop.tsx
+++ b/src/components/bottomSheetBackdrop/BottomSheetBackdrop.tsx
@@ -115,8 +115,11 @@ const BottomSheetBackdropComponent = ({
   //#endregion
 
   //#region effects
+  // Interpolated index can sit at 0.00001 after a geometry write that isn't
+  // bit-identical to the snap Y. Round to the discrete snap for hit-testing;
+  // opacity still follows the raw interpolated value.
   useAnimatedReaction(
-    () => animatedIndex.value <= disappearsOnIndex,
+    () => Math.round(animatedIndex.value) <= disappearsOnIndex,
     (shouldDisableTouchability, previous) => {
       if (shouldDisableTouchability === previous) {
         return;


### PR DESCRIPTION
## Summary

After an instant setToIndex (e.g. Android rotation), the sheet can look collapsed while animatedIndex is still a hair above 0 because position isn’t bit-identical to the snap Y. The backdrop then keeps pointerEvents: 'auto' and swallows taps (header back, composer) while pans still reach the list.

setToIndex now writes animatedCurrentIndex as well as position / next index, including the no-op path.
Backdrop hit-testing uses Math.round(animatedIndex) so pointer events follow the discrete snap. Opacity is unchanged.